### PR TITLE
[FIX:DB] Adding the unique property to the role name

### DIFF
--- a/database/migrations/20221129010000-create-role.js
+++ b/database/migrations/20221129010000-create-role.js
@@ -16,6 +16,7 @@ module.exports = {
                 },
                 name: {
                     allowNull: false,
+                    unique: true,
                     type: sequelize.STRING,
                 },
                 description: {

--- a/database/models/role.js
+++ b/database/models/role.js
@@ -20,6 +20,7 @@ module.exports = (sequelize, DataTypes) => {
                 type: DataTypes.INTEGER,
             },
             name: {
+                unique: true,
                 allowNull: false,
                 type: DataTypes.STRING,
             },


### PR DESCRIPTION
## Description
The "unique" property is added in name of roles to avoid having multiple rows

## Evidence:
## Model
![image](https://user-images.githubusercontent.com/82684580/204637262-a091d560-2975-4f3a-af19-53b117c64b55.png)

## Migration
![image](https://user-images.githubusercontent.com/82684580/204637359-124a15b1-f986-434e-8c86-aa004a8e0921.png)
